### PR TITLE
Update pca.md

### DIFF
--- a/tutorials/pca.md
+++ b/tutorials/pca.md
@@ -55,7 +55,7 @@ Two plot files `pca_projection_1_2.png` and `pca_projection_3_4.png` will be cre
 You can also supply a labels file to color the points by population, genotype, etc..
 
 ```bash
-$ asaph_genotype \
+$ asaph_pca \
     --workdir <workdir> \
 	plot-projections \
 	--pairs 1 2 3 4 \


### PR DESCRIPTION
I found an error using "asaph_genotype" function when I tried to plot labels for the PCA projection plots (asaph_genotype: error: argument mode: invalid choice: 'chr2' (choose from 'test-pcs', 'cluster', 'sweep-parameters', 'evaluate-predicted-genotypes').

Once I changed this to "asaph_pca", I got the correct output. I just wanted to submit a pull request to update the manual so others do not have this error!